### PR TITLE
Stringent parsing

### DIFF
--- a/src/zts.zig
+++ b/src/zts.zig
@@ -4,7 +4,6 @@ const Mode = enum {
     find_directive,
     reading_directive_name,
     content_line,
-    content_start,
 };
 
 // s will return the section from the data, as a comptime known string
@@ -66,27 +65,6 @@ pub fn s(comptime str: []const u8, comptime directive: ?[]const u8) []const u8 {
                         maybe_directive_start = directive_start;
                     },
                     else => {},
-                }
-            },
-            .content_start => {
-                // if the first non-whitespace char of content is a .
-                // then we are in find directive mode !
-                switch (c) {
-                    '\n' => {
-                        mode = .find_directive;
-                        last_start_of_line = index + 1;
-                    },
-                    ' ', '\t' => {}, // eat whitespace
-                    '.' => {
-                        // thinks we are looking for content, but last directive
-                        // was empty, so start a new directive on this line
-                        maybe_directive_start = index;
-                        last_start_of_line = content_start;
-                        mode = .reading_directive_name;
-                    },
-                    else => {
-                        mode = .content_line;
-                    },
                 }
             },
             .content_line => { // just eat the rest of the line till the next line
@@ -170,27 +148,6 @@ pub fn lookup(str: []const u8, directive: ?[]const u8) ?[]const u8 {
                         maybe_directive_start = directive_start;
                     },
                     else => {},
-                }
-            },
-            .content_start => {
-                // if the first non-whitespace char of content is a .
-                // then we are in find directive mode !
-                switch (c) {
-                    '\n' => {
-                        mode = .find_directive;
-                        last_start_of_line = index + 1;
-                    },
-                    ' ', '\t' => {}, // eat whitespace
-                    '.' => {
-                        // thinks we are looking for content, but last directive
-                        // was empty, so start a new directive on this line
-                        maybe_directive_start = index;
-                        last_start_of_line = content_start;
-                        mode = .reading_directive_name;
-                    },
-                    else => {
-                        mode = .content_line;
-                    },
                 }
             },
             .content_line => { // just eat the rest of the line till the next line

--- a/src/zts.zig
+++ b/src/zts.zig
@@ -59,7 +59,7 @@ pub fn s(comptime str: []const u8, comptime directive: ?[]const u8) []const u8 {
                         last_start_of_line = index + 1;
                         mode = .find_directive;
                     },
-                    ' ', '\t', '.', '{', '}', '[', ']', ':' => { // invalid chars for directive name
+                    '\x01'...'\t', '\x0B'...'\x1F', ' '...'/', ':'...'@', '{'...'}', '['...'^', '`' => { // invalid chars for directive name
                         // @compileLog("false alarm scanning directive, back to content", str[maybe_directive_start .. index + 1]);
                         mode = .content_line;
                         maybe_directive_start = directive_start;
@@ -142,7 +142,7 @@ pub fn lookup(str: []const u8, directive: ?[]const u8) ?[]const u8 {
                         last_start_of_line = index + 1;
                         mode = .find_directive;
                     },
-                    ' ', '\t', '.', '{', '}', '[', ']', ':' => { // invalid chars for directive name
+                    '\x00'...'\t', '\x0B'...'\x1F', ' '...'/', ':'...'@', '{'...'}', '['...'^', '`' => { // invalid chars for directive name
                         // @compileLog("false alarm scanning directive, back to content", str[maybe_directive_start .. index + 1]);
                         mode = .content_line;
                         maybe_directive_start = directive_start;

--- a/src/zts.zig
+++ b/src/zts.zig
@@ -57,7 +57,8 @@ pub fn s(comptime str: []const u8, comptime directive: ?[]const u8) []const u8 {
                             content_end = str.len - 1;
                             // @compileLog("found directive in data", directive_name, "starts at", content_start, "runs to", content_end);
                         }
-                        mode = .content_start;
+                        last_start_of_line = index + 1;
+                        mode = .find_directive;
                     },
                     ' ', '\t', '.', '{', '}', '[', ']', ':' => { // invalid chars for directive name
                         // @compileLog("false alarm scanning directive, back to content", str[maybe_directive_start .. index + 1]);
@@ -160,7 +161,8 @@ pub fn lookup(str: []const u8, directive: ?[]const u8) ?[]const u8 {
                             content_end = str.len - 1;
                             // @compileLog("found directive in data", directive_name, "starts at", content_start, "runs to", content_end);
                         }
-                        mode = .content_start;
+                        last_start_of_line = index + 1;
+                        mode = .find_directive;
                     },
                     ' ', '\t', '.', '{', '}', '[', ']', ':' => { // invalid chars for directive name
                         // @compileLog("false alarm scanning directive, back to content", str[maybe_directive_start .. index + 1]);

--- a/src/zts.zig
+++ b/src/zts.zig
@@ -31,7 +31,7 @@ pub fn s(comptime str: []const u8, comptime directive: ?[]const u8) []const u8 {
                     '\n' => {
                         last_start_of_line = index + 1;
                     },
-                    else => mode = .content_start,
+                    else => mode = .content_line,
                 }
             },
             .reading_directive_name => {
@@ -134,7 +134,7 @@ pub fn lookup(str: []const u8, directive: ?[]const u8) ?[]const u8 {
                     '\n' => {
                         last_start_of_line = index + 1;
                     },
-                    else => mode = .content_start,
+                    else => mode = .content_line,
                 }
             },
             .reading_directive_name => {

--- a/src/zts.zig
+++ b/src/zts.zig
@@ -61,7 +61,7 @@ pub fn s(comptime str: []const u8, comptime directive: ?[]const u8) []const u8 {
                     },
                     ' ', '\t', '.', '{', '}', '[', ']', ':' => { // invalid chars for directive name
                         // @compileLog("false alarm scanning directive, back to content", str[maybe_directive_start .. index + 1]);
-                        mode = .content_start;
+                        mode = .content_line;
                         maybe_directive_start = directive_start;
                     },
                     else => {},
@@ -164,7 +164,7 @@ pub fn lookup(str: []const u8, directive: ?[]const u8) ?[]const u8 {
                     },
                     ' ', '\t', '.', '{', '}', '[', ']', ':' => { // invalid chars for directive name
                         // @compileLog("false alarm scanning directive, back to content", str[maybe_directive_start .. index + 1]);
-                        mode = .content_start;
+                        mode = .content_line;
                         maybe_directive_start = directive_start;
                     },
                     else => {},


### PR DESCRIPTION
Updates the parser to be more stringent when parsing directive names.
And fixes an issue parsing `x.function();` as a label.

If there's anything you don't want from this PR let me know and I can drop the commit.